### PR TITLE
Add merge strategy for generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Generated HTML files with large embedded data — use "ours" merge strategy
+# to auto-resolve conflicts (the auto-update job regenerates these on main).
+# Requires one-time setup: git config merge.ours.driver true
+docs/map.html merge=ours

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,16 @@ Key columns added at each stage:
 
 The site is served via GitHub Pages from the `docs/` directory on the `main` branch.
 
+## Branching
+
+Files in `docs/` are generated output. On feature branches, only commit changes to scripts — do not commit regenerated `docs/` files. The auto-update job on `main` will regenerate them after merge. Run the generation scripts locally to verify your changes, but leave the output uncommitted.
+
+A `.gitattributes` merge strategy auto-resolves conflicts in `docs/map.html`. New clones need a one-time setup:
+
+```
+git config merge.ours.driver true
+```
+
 ## Environment
 
 - Python 3.12+, managed with `uv`


### PR DESCRIPTION
## Summary
- Add `.gitattributes` with `merge=ours` strategy for `docs/map.html` to auto-resolve conflicts caused by auto-update commits on main
- Document branching workflow in `CLAUDE.md`: don't commit regenerated `docs/` on feature branches, and one-time `git config merge.ours.driver true` setup for new clones

## Test plan
- [ ] Verify `.gitattributes` is picked up: create a test branch, make a conflicting change to `docs/map.html`, and confirm the merge auto-resolves
- [ ] Confirm GitHub Pages still serves correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)