### PR TITLE
Add Plausible custom event tracking for user interactions

### DIFF
--- a/docs/filter_panel.html
+++ b/docs/filter_panel.html
@@ -374,7 +374,10 @@
       });
 
       // Reset button
-      document.getElementById('filter-reset-inline').addEventListener('click', () => this.resetAll());
+      document.getElementById('filter-reset-inline').addEventListener('click', () => {
+        this.resetAll();
+        track('Map Filter Reset');
+      });
 
       this.updateMatchCount();
     }
@@ -430,6 +433,7 @@
         group.classList.toggle('filter-group-active', !(lo <= min && hi >= sliderMax));
         this.applyRangeFilter(filterId);
         this._updateResetButtonState();
+        trackDebounced('Map Date Range', () => ({min: fmt(lo), max: fmt(hi)}));
       };
 
       minInput.addEventListener('input', onInput);
@@ -519,6 +523,7 @@
         this.updateMatchCount();
         this.serializeState();
         this._updateResetButtonState();
+        track('Map Filter', {group: name, values: Array.from(checked).join(',')});
       };
 
       checkboxes.forEach(cb => cb.addEventListener('change', onChange));
@@ -548,6 +553,7 @@
         origHandler(field);
         self.onColormapChanged(field);
         self.serializeState();
+        track('Map Colormap', {field: field.field || field.description || String(field)});
       };
     }
 
@@ -866,6 +872,15 @@
     patchHighlightPoints(datamap);
     const filterPanel = new FilterPanel(datamap, hoverData, FILTER_CONFIG);
     filterPanel.restoreFromURL();
+
+    // Track search usage
+    const searchInput = document.querySelector('#search-container input');
+    if (searchInput) {
+      searchInput.addEventListener('input', function() {
+        const q = searchInput.value.trim();
+        if (q) trackDebounced('Map Search', () => ({query: q}));
+      });
+    }
   });
 })();
 </script>

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -8,7 +8,7 @@ import glasbey
 import numpy as np
 import pandas as pd
 
-from nav import NAV_CSS, PLAUSIBLE_SCRIPT, nav_html
+from nav import NAV_CSS, PLAUSIBLE_EVENTS_SCRIPT, PLAUSIBLE_SCRIPT, nav_html
 
 ROOT = Path(__file__).resolve().parent.parent
 INPUT_PATH = ROOT / "data" / "enriched.parquet"
@@ -272,6 +272,7 @@ def page_shell(title: str, nav_active: str, body_content: str, extra_head: str =
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Newsreader:opsz,wght@6..72,400&display=swap" rel="stylesheet">
 {PLAUSIBLE_SCRIPT}
+{PLAUSIBLE_EVENTS_SCRIPT}
 {TAILWIND_CONFIG}
 {NAV_CSS}
 {extra_head}
@@ -487,15 +488,28 @@ fetch("data/entries.json")
       }});
     }}
 
+    var _tableReady = false;
     table.on("dataFiltered", function(filters, rows) {{
       updateKpis(rows);
+      if (!_tableReady) return;
+      var hf = table.getHeaderFilters();
+      hf.forEach(function(f) {{
+        if (f.value && String(f.value).length > 0) {{
+          track('Filter Applied', {{column: f.field, value: String(f.value)}});
+        }}
+      }});
     }});
 
-    table.on("dataSorted", applyDateBanding);
+    table.on("dataSorted", function(sorters, rows) {{
+      applyDateBanding();
+      if (!_tableReady || !sorters.length) return;
+      track('Table Sorted', {{column: sorters[0].field, direction: sorters[0].dir}});
+    }});
     table.on("renderComplete", applyDateBanding);
 
     table.on("tableBuilt", function() {{
       updateKpis(table.getRows("active"));
+      _tableReady = true;
     }});
   }});
 </script>
@@ -600,6 +614,7 @@ fetch('data/analysis.json')
           yAxis: {name: trendMode === 'count' ? 'Entries' : '% of Entries', max: trendMode === 'pct' ? 100 : null},
           series: makeTrendSeries(trendMode),
         });
+        track('Trend Toggle', {mode: trendMode});
       });
     }
 

--- a/scripts/mapviz.py
+++ b/scripts/mapviz.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import datamapplot
 
-from nav import NAV_CSS, PLAUSIBLE_SCRIPT, nav_html
+from nav import NAV_CSS, PLAUSIBLE_EVENTS_SCRIPT, PLAUSIBLE_SCRIPT, nav_html
 import glasbey
 import numpy as np
 import pandas as pd
@@ -358,6 +358,7 @@ def _inject_nav(html_path):
         'family=Newsreader:opsz,wght@6..72,400&display=swap" rel="stylesheet">\n'
         '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
         f'{PLAUSIBLE_SCRIPT}\n'
+        f'{PLAUSIBLE_EVENTS_SCRIPT}\n'
         f'{NAV_CSS}\n'
         f'{fixed_wrapper_css}\n'
     )

--- a/scripts/nav.py
+++ b/scripts/nav.py
@@ -79,6 +79,15 @@ PLAUSIBLE_SCRIPT = (
     "</script>"
 )
 
+PLAUSIBLE_EVENTS_SCRIPT = (
+    "<script>\n"
+    "function track(name,props){if(window.plausible)plausible(name,{props:props||{}})}\n"
+    "var _trackTimers={};\n"
+    "function trackDebounced(name,propsFn,ms){clearTimeout(_trackTimers[name]);"
+    "_trackTimers[name]=setTimeout(function(){track(name,propsFn())},ms||500)}\n"
+    "</script>"
+)
+
 PAGES = [("Explorer", "index.html"), ("Analysis", "analysis.html"), ("Map", "map.html")]
 
 


### PR DESCRIPTION
## Summary
- Add 9 custom Plausible events across all three pages (Explorer, Analysis, Map) to understand how users interact with the site
- Events include: Filter Applied, Table Sorted, Trend Toggle, Map Filter, Map Date Range, Map Filter Reset, Map Colormap, Map Search
- All events send property values for breakdown reports in Plausible (e.g., which columns are filtered, which colormaps are selected)
- Shared `track()` and `trackDebounced()` helpers in `nav.py` prevent duplicate code and handle high-frequency events (date slider, search input)
- `_tableReady` guard on Explorer page prevents events from firing on initial page load

## Test plan
- [x] `uv run python scripts/dashboard.py` generates without errors
- [x] `uv run python scripts/mapviz.py` generates without errors
- [x] Verified all tracking functions (`track`, `trackDebounced`, `plausible`) are defined on all three pages
- [x] Verified no events fire on initial Explorer page load
- [x] Verified `Table Sorted` fires with correct `{column, direction}` props
- [x] Verified `Filter Applied` fires with correct `{column, value}` props
- [x] Verified `Trend Toggle` fires with correct `{mode}` prop
- [x] Verified `Map Filter Reset` fires
- [x] Verified `Map Filter` fires with correct `{group, values}` props
- [x] Verified `Map Search` fires with debounced `{query}` prop
- [x] Verified `Map Colormap` fires with string `{field}` prop (not full config object)

🤖 Generated with [Claude Code](https://claude.com/claude-code)