### PR TITLE
Fix pipeline-failure label creation in notify job

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -58,6 +58,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          gh label create "pipeline-failure" --color "d73a4a" --description "Automated pipeline failure" 2>/dev/null || true
           existing=$(gh issue list --label "pipeline-failure" --state open --json number --jq 'length')
           if [ "$existing" -gt 0 ]; then
             echo "Open pipeline-failure issue already exists, skipping."


### PR DESCRIPTION
## Summary
- The notify job failed because the `pipeline-failure` label didn't exist on the repo
- Adds `gh label create` (idempotent) before attempting to create the issue

## Test plan
- [ ] Trigger a pipeline failure and verify the issue is created with the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)