### PR TITLE
Add parser tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+          enable-cache: true
+      - run: uv sync --extra dev
+      - run: uv run pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
     "glasbey>=0.2",
 ]
 
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,0 +1,187 @@
+"""Tests for scripts/parse.py changelog parser."""
+
+from pathlib import Path
+
+from scripts.parse import parse_changelog
+
+
+def _write_changelog(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "CHANGELOG.md"
+    p.write_text(content)
+    return p
+
+
+def test_basic_parsing(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 1.0.0
+- Added new feature
+- Fixed a bug
+""")
+    entries = parse_changelog(path, {"1.0.0": "2025-01-01"})
+    assert len(entries) == 2
+    assert entries[0]["version"] == "1.0.0"
+    assert entries[0]["text"] == "Added new feature"
+    assert entries[0]["entry_index"] == 0
+    assert entries[1]["entry_index"] == 1
+
+
+def test_multiple_versions(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 2.0.0
+- Added X
+
+## 1.0.0
+- Fixed Y
+""")
+    entries = parse_changelog(path, {})
+    assert len(entries) == 2
+    assert entries[0]["version"] == "2.0.0"
+    assert entries[1]["version"] == "1.0.0"
+
+
+def test_version_dates(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 2.0.0
+- Entry A
+
+## 1.0.0
+- Entry B
+""")
+    entries = parse_changelog(path, {"2.0.0": "2025-06-01"})
+    assert entries[0]["date"] == "2025-06-01"
+    assert entries[1]["date"] is None
+
+
+def test_prefix_detection(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 1.0.0
+- Added a widget
+- Fixed the crash
+- Improved performance
+- Changed the default
+- Removed old code
+- Some other thing
+""")
+    entries = parse_changelog(path, {})
+    assert entries[0]["prefix"] == "Added"
+    assert entries[1]["prefix"] == "Fixed"
+    assert entries[2]["prefix"] == "Improved"
+    assert entries[3]["prefix"] == "Changed"
+    assert entries[4]["prefix"] == "Removed"
+    assert entries[5]["prefix"] is None
+
+
+def test_prefix_normalization_case(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 1.0.0
+- added lowercase prefix
+""")
+    entries = parse_changelog(path, {})
+    assert entries[0]["prefix"] == "Added"
+
+
+def test_breaking_change_prefix_normalized(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 1.0.0
+- Breaking change: removed old API
+""")
+    entries = parse_changelog(path, {})
+    assert entries[0]["prefix"] == "Breaking"
+    assert entries[0]["is_breaking"] is True
+
+
+def test_vscode_detection(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 1.0.0
+- [VSCode] Fixed sidebar issue
+- Fixed regular issue
+""")
+    entries = parse_changelog(path, {})
+    assert entries[0]["is_vscode"] is True
+    assert entries[0]["prefix"] == "Fixed"
+    assert entries[1]["is_vscode"] is False
+
+
+def test_bold_prefix_stripping(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 1.0.0
+- **Security:** Fixed silent sandbox disable
+""")
+    entries = parse_changelog(path, {})
+    assert entries[0]["prefix"] == "Fixed"
+
+
+def test_backtick_stripping(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 1.0.0
+- `some_flag` Added support for new flag
+""")
+    entries = parse_changelog(path, {})
+    assert entries[0]["prefix"] == "Added"
+
+
+def test_breaking_change_in_text(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 1.0.0
+- Removed old API (breaking change)
+""")
+    entries = parse_changelog(path, {})
+    assert entries[0]["is_breaking"] is True
+
+
+def test_non_breaking_entry(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 1.0.0
+- Added a feature
+""")
+    entries = parse_changelog(path, {})
+    assert entries[0]["is_breaking"] is False
+
+
+def test_lines_before_first_version_skipped(tmp_path):
+    path = _write_changelog(tmp_path, """\
+# Changelog
+
+Some preamble text.
+
+- This should be ignored
+
+## 1.0.0
+- Real entry
+""")
+    entries = parse_changelog(path, {})
+    assert len(entries) == 1
+    assert entries[0]["text"] == "Real entry"
+
+
+def test_non_entry_lines_skipped(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 1.0.0
+- Entry one
+Some continuation text
+### Subsection
+- Entry two
+""")
+    entries = parse_changelog(path, {})
+    assert len(entries) == 2
+
+
+def test_empty_changelog(tmp_path):
+    path = _write_changelog(tmp_path, "")
+    entries = parse_changelog(path, {})
+    assert entries == []
+
+
+def test_entry_index_resets_per_version(tmp_path):
+    path = _write_changelog(tmp_path, """\
+## 2.0.0
+- First in v2
+- Second in v2
+
+## 1.0.0
+- First in v1
+""")
+    entries = parse_changelog(path, {})
+    assert entries[0]["entry_index"] == 0
+    assert entries[1]["entry_index"] == 1
+    assert entries[2]["entry_index"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -313,6 +313,11 @@ dependencies = [
     { name = "umap-learn" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40" },
@@ -326,11 +331,13 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26" },
     { name = "pandas", specifier = ">=2.2" },
     { name = "pyarrow", specifier = ">=18.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "toponymy", specifier = ">=0.4" },
     { name = "transformers", specifier = ">=4.0" },
     { name = "umap-learn", specifier = ">=0.5" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "click"
@@ -1006,6 +1013,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
 ]
 
 [[package]]
@@ -2022,6 +2038,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2341,6 +2366,22 @@ name = "pyqtree"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/90/2905247e80944d2ce6b36a69fb995709cef25c409018f7471fd88cc1122a/Pyqtree-1.0.0.tar.gz", hash = "sha256:4f36d5160ddf170d7245e9c7102a45211b85003383dd552b6cd109e50cc3af81", size = 5239 }
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
+]
 
 [[package]]
 name = "python-dateutil"


### PR DESCRIPTION
## Summary
- Add 15 unit tests for the changelog parser (`scripts/parse.py`), covering version/entry extraction, prefix detection and normalization, `[VSCode]` tags, bold/backtick stripping, breaking change detection, and edge cases
- Add pytest as an optional dev dependency (`uv sync --extra dev`)
- Add GitHub Actions workflow to run tests on PRs and pushes to main

## Test plan
- [x] All 15 tests pass locally (`uv run --extra dev pytest tests/test_parse.py -v`)
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)