### PR TITLE
Escape hover text in map visualization to prevent XSS

### DIFF
--- a/scripts/mapviz.py
+++ b/scripts/mapviz.py
@@ -77,7 +77,7 @@ def main():
         t = str(t).strip()
         if len(t) > MAX_HOVER_CHARS:
             t = t[:MAX_HOVER_CHARS].rsplit(" ", 1)[0] + "…"
-        hover_text.append(t)
+        hover_text.append(escape(t))
 
     hover_text_html_template = (
         '<div class="hc">'


### PR DESCRIPTION
## Summary
- Apply `html.escape()` to hover text values from CHANGELOG.md before passing them to DataMapPlot, closing an XSS gap where all other fields were already escaped via `_esc()`

## Test plan
- [x] Full pipeline ran successfully with the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)