### PR TITLE
Include about.html in auto-update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           git add data/
           git add -f CHANGELOG.md
-          git add -f docs/index.html docs/analysis.html docs/map.html docs/data/
+          git add -f docs/index.html docs/analysis.html docs/about.html docs/map.html docs/data/
           git diff --cached --quiet && exit 0
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- Add `docs/about.html` to the `git add` list in the update workflow so the About page gets committed on each auto-update run

## Test plan
- [ ] Verify the next scheduled workflow run (hourly at :25) commits `about.html` alongside the other pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)