### PR TITLE
Redesign audience colors and unify field presentation

### DIFF
--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -210,10 +210,10 @@ TABULATOR_CSS = """
 /* Table pills & indicators */
 .pill {
     display: inline-block; padding: 2px 8px; border-radius: 3px;
-    font-size: 0.72rem; color: #fff; font-weight: 600;
+    font-size: 0.72rem; font-weight: 600;
     line-height: 1.4; white-space: nowrap;
 }
-.complexity-indicator { font-weight: 600; white-space: nowrap; }
+.field-indicator, .complexity-indicator { font-weight: 600; white-space: nowrap; }
 /* Tabulator responsive collapse */
 .tabulator-responsive-collapse { padding: 8px 12px; }
 .tabulator-responsive-collapse table { font-size: 0.75rem; width: 100%; }
@@ -318,6 +318,7 @@ var TYPE_ICONS = {{feature:"\u2726", bugfix:"\u2715", improvement:"\u2191", brea
 var COMPLEXITY_COLORS = {complexity_colors_js};
 var COMPLEXITY_DOTS = {{minor:"\u25cf\u25cb\u25cb", moderate:"\u25cf\u25cf\u25cb", major:"\u25cf\u25cf\u25cf"}};
 var AUDIENCE_COLORS = {audience_colors_js};
+var AUDIENCE_ICONS = {{interactive_user:"\u25c9", extension_developer:"\u2b21", admin:"\u26ed", sdk_developer:"\u2692"}};
 </script>
 
 <script>
@@ -436,8 +437,8 @@ fetch("data/entries.json")
           headerFilterFunc: "in",
           formatter: function(cell) {{
             var v = cell.getValue();
-            var bg = CAT_COLORS[v] || "#888";
-            return '<span class="pill" style="background:' + bg + ';">' + v + '</span>';
+            var c = CAT_COLORS[v] || "#888";
+            return '<span class="pill" style="background:' + c + '18;color:' + c + ';border:1px solid ' + c + '30;">' + v.replace(/_/g, ' ') + '</span>';
           }}
         }},
         {{title: "Type", field: "change_type", width: 140, responsive: 2,
@@ -446,9 +447,9 @@ fetch("data/entries.json")
           headerFilterFunc: "in",
           formatter: function(cell) {{
             var v = cell.getValue();
-            var bg = TYPE_COLORS[v] || "#888";
+            var color = TYPE_COLORS[v] || "#888";
             var icon = TYPE_ICONS[v] || "";
-            return '<span class="pill" style="background:' + bg + ';">' + icon + ' ' + v + '</span>';
+            return '<span class="field-indicator" style="color:' + color + ';">' + icon + ' ' + v + '</span>';
           }}
         }},
         {{title: "Audience", field: "audience", width: 160, responsive: 3,
@@ -458,8 +459,9 @@ fetch("data/entries.json")
           headerFilterFunc: "in",
           formatter: function(cell) {{
             var v = cell.getValue();
-            var bg = AUDIENCE_COLORS[v] || "#888";
-            return '<span class="pill" style="background:' + bg + ';">' + v.replace(/_/g, ' ') + '</span>';
+            var color = AUDIENCE_COLORS[v] || "#888";
+            var icon = AUDIENCE_ICONS[v] || "";
+            return '<span class="field-indicator" style="color:' + color + ';">' + icon + ' ' + v.replace(/_/g, ' ') + '</span>';
           }}
         }},
         {{title: "Complexity", field: "complexity", width: 130, responsive: 3,

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -49,10 +49,10 @@ COMPLEXITY_COLORS = {
 AUDIENCES = ["interactive_user", "sdk_developer", "admin", "extension_developer"]
 
 AUDIENCE_COLORS = {
-    "interactive_user": "#7c3aed",     # violet
-    "extension_developer": "#e85d04",  # orange
-    "admin": "#0e7490",                # teal
-    "sdk_developer": "#be185d",        # pink
+    "interactive_user": "#18756e",     # teal
+    "sdk_developer": "#592c85",        # violet
+    "admin": "#72721c",                # olive
+    "extension_developer": "#852c59",  # rose
 }
 
 

--- a/scripts/mapviz.py
+++ b/scripts/mapviz.py
@@ -48,10 +48,10 @@ COMPLEXITY_COLORS = {
 }
 
 AUDIENCE_COLORS = {
-    "interactive_user": "#7c3aed",     # violet
-    "extension_developer": "#e85d04",  # orange
-    "admin": "#0e7490",                # teal
-    "sdk_developer": "#be185d",        # pink
+    "interactive_user": "#18756e",     # teal
+    "sdk_developer": "#592c85",        # violet
+    "admin": "#72721c",                # olive
+    "extension_developer": "#852c59",  # rose
 }
 
 # Marker sizes by complexity


### PR DESCRIPTION
## Summary
- Replace high-saturation audience palette (which had a WCAG AA failure and near-identical orange to change_type's "breaking") with a lower-saturation set from unclaimed hue regions: teal, violet, olive, rose
- Map interactive_user to the most recessive color (teal) since it accounts for 75% of entries
- Unify field presentation between map tooltips and explorer table: category uses tinted pill with colored text, type/audience use icon + colored text instead of solid pills

## Test plan
- [ ] Verify explorer table renders category as tinted pills with colored text and no underscores
- [ ] Verify type and audience columns show icon + colored text (not solid pills)
- [ ] Verify audience icons match between map tooltips and explorer table
- [ ] Verify all audience pill text is legible (WCAG AA contrast ≥ 4.5:1)
- [ ] Check analysis page charts use updated audience colors
- [ ] Check map colormap selector shows updated audience colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)