### PR TITLE
Add independence disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Claude Code Changelog Analysis
 
+> **Note:** This is an independent community project, not affiliated with or endorsed by Anthropic.
+
 A site for staying up-to-date on the latest changes to [Claude Code](https://github.com/anthropics/claude-code). Fetches `CHANGELOG.md` from the upstream repo, parses entries, enriches them with LLM-derived classifications, generates embeddings, and produces a browsable site.
 
 **[View the dashboard](https://stevenfazzio.github.io/claude-code-changelog-analysis/)**

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -962,7 +962,8 @@ def render_about_page() -> str:
 <hr>
 
 <p>
-  Built by Steven Fazzio. Source code is on
+  This is an independent community project, not affiliated with or endorsed by
+  Anthropic. Built by Steven Fazzio. Source code is on
   <a href="https://github.com/stevenfazzio/claude-code-changelog-analysis">GitHub</a>
   &mdash; feel free to
   <a href="https://github.com/stevenfazzio/claude-code-changelog-analysis/issues">open an issue</a>


### PR DESCRIPTION
## Summary
- Add disclaimer to README (blockquote after heading) noting this is an independent community project, not affiliated with or endorsed by Anthropic
- Add the same disclaimer to the About page footer in `dashboard.py`

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Run `uv run python scripts/dashboard.py` and verify the About page footer includes the disclaimer

🤖 Generated with [Claude Code](https://claude.com/claude-code)