### PR TITLE
Add social/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ CHANGELOG.md
 
 # Eval experiment artifacts
 data/eval/
+
+# Social media assets
+social/


### PR DESCRIPTION
## Summary
- Adds `social/` to `.gitignore` so social media assets (screenshots, GIFs, draft posts) stay untracked

## Test plan
- [x] Verify `social/` directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)