### PR TITLE
Improve enrichment prompt: rename categories, structured output, few-shot examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,6 @@ git config merge.ours.driver true
 
 The enrich stage classifies entries along these dimensions:
 - **category**: terminal, input, skills, sessions, mcp, voice, auth, ide, hooks, permissions, performance, agents, plugins, config, api, sdk, other
-- **change_type**: feature, bugfix, improvement, breaking, internal
+- **change_type**: feature, bugfix, improvement, breaking
 - **complexity**: minor, moderate, major
 - **audience**: interactive_user, sdk_developer, admin, extension_developer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ git config merge.ours.driver true
 ## Categories and Enums
 
 The enrich stage classifies entries along these dimensions:
-- **category**: terminal, input, slash_commands, sessions, mcp, voice, auth, ide, hooks, permissions, performance, agents, plugins, config, api, sdk, other
+- **category**: terminal, input, skills, sessions, mcp, voice, auth, ide, hooks, permissions, performance, agents, plugins, config, api, sdk, other
 - **change_type**: feature, bugfix, improvement, breaking, internal
 - **complexity**: minor, moderate, major
 - **audience**: interactive_user, sdk_developer, admin, extension_developer

--- a/data/embeddings.parquet
+++ b/data/embeddings.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48791aa0c8f10b056da2b9f9aae1cfd69127da1777c3d9bd2697181cc791f3c9
-size 9412066
+oid sha256:d6f4381b4db605fce29387d2047aaabfce34ca9379272093df494d0c5a743cf5
+size 9411868

--- a/data/enriched.parquet
+++ b/data/enriched.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a031b57ccaa3ff17ce6033a56607078d22e4cdc5af0d0f1d5d4043adabcde7b
-size 120564
+oid sha256:7cf4c02186527e4a19f9a0dc01a353cd0e7a0064529cae2314d33f05fd44e0b8
+size 120363

--- a/data/map_data.parquet
+++ b/data/map_data.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c25e79d010f268191d57edb61ff8305b85360ec26599682e34ce85d3f40bf2f
-size 9440371
+oid sha256:9278c8a96d28c6e1275e178445f26dcfa68ed3f7aa84d3c62b87cb4f21a8865a
+size 9440452

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -19,7 +19,7 @@ DATA_DIR = OUTPUT_DIR / "data"
 
 # ── Unified color palette ────────────────────────────────────────────────────
 CATEGORIES = [
-    "terminal", "input", "slash_commands", "sessions",
+    "terminal", "input", "skills", "sessions",
     "mcp", "voice", "auth", "ide", "hooks", "permissions",
     "performance", "agents", "plugins", "config", "api", "sdk", "other",
 ]
@@ -37,7 +37,6 @@ TYPE_COLORS = {
     "bugfix": "#c4382a",
     "improvement": "#2e6eb8",
     "breaking": "#d4710e",
-    "internal": "#777777",
 }
 
 COMPLEXITY_COLORS = {
@@ -322,7 +321,7 @@ def render_explorer_page(df: pd.DataFrame) -> str:
 <script>
 var CAT_COLORS = {cat_colors_js};
 var TYPE_COLORS = {type_colors_js};
-var TYPE_ICONS = {{feature:"\u2726", bugfix:"\u2715", improvement:"\u2191", breaking:"\u26a0", internal:"\u2699"}};
+var TYPE_ICONS = {{feature:"\u2726", bugfix:"\u2715", improvement:"\u2191", breaking:"\u26a0"}};
 var COMPLEXITY_COLORS = {complexity_colors_js};
 var COMPLEXITY_DOTS = {{minor:"\u25cf\u25cb\u25cb", moderate:"\u25cf\u25cf\u25cb", major:"\u25cf\u25cf\u25cf"}};
 var AUDIENCE_COLORS = {audience_colors_js};
@@ -973,11 +972,11 @@ def render_about_page() -> str:
 </p>
 <ul>
   <li><strong>Category</strong> &mdash; the area of Claude Code affected:
-    <span class="dim">terminal, input, slash_commands, sessions, mcp, voice, auth,
+    <span class="dim">terminal, input, skills, sessions, mcp, voice, auth,
     ide, hooks, permissions, performance, agents, plugins, config, api, sdk,
     other</span></li>
   <li><strong>Change type</strong> &mdash;
-    <span class="dim">feature, bugfix, improvement, breaking, internal</span></li>
+    <span class="dim">feature, bugfix, improvement, breaking</span></li>
   <li><strong>Complexity</strong> &mdash;
     <span class="dim">minor, moderate, major</span></li>
   <li><strong>Audience</strong> &mdash; who the change matters most to:

--- a/scripts/enrich.py
+++ b/scripts/enrich.py
@@ -15,7 +15,7 @@ INPUT_PATH = ROOT / "data" / "raw_entries.parquet"
 OUTPUT_PATH = ROOT / "data" / "enriched.parquet"
 
 CATEGORIES = [
-    "terminal", "input", "slash_commands", "sessions",
+    "terminal", "input", "skills", "sessions",
     "mcp", "voice", "auth", "ide", "hooks", "permissions",
     "performance", "agents", "plugins", "config", "api", "sdk", "other",
 ]
@@ -40,7 +40,7 @@ For each entry, output a JSON array of objects with these fields:
 Pick the MOST SPECIFIC category that applies:
 - "terminal" = terminal rendering, display, cursor, flickering, UI layout, spinner, progress indicators
 - "input" = keyboard handling, text entry, vim mode, readline keybindings, CJK/IME, clipboard/paste
-- "slash_commands" = slash command system, autocomplete, custom commands (/help, /config, /resume etc.)
+- "skills" = skills framework, slash commands (built-in and custom), .claude/commands/, skill discovery/install, skill frontmatter and behavior
 - "sessions" = session resume, session management, remote control, conversation compaction, history
 - "mcp" = MCP server management, MCP tool behavior, MCP OAuth, MCP resources
 - "voice" = voice mode, audio, microphone, push-to-talk
@@ -50,7 +50,7 @@ Pick the MOST SPECIFIC category that applies:
 - "permissions" = permission prompts, allow/deny, sandbox, tool approval
 - "performance" = speed, memory, startup time, caching, token usage optimization
 - "agents" = subagents (Explore, Plan, etc.), background tasks/agents, worktrees, task tools, agent teams
-- "plugins" = plugin system, marketplace, plugin install/discover, skills
+- "plugins" = plugin system, marketplace, plugin install/uninstall/discover/validate, plugin configuration, plugin trust/permissions
 - "config" = settings, env vars, configuration files, managed settings, .claude/ files, CLAUDE.md
 - "api" = API integration, model providers, Bedrock, Vertex, model selection, rate limits
 - "sdk" = SDK features, SDK messages, SDK configuration, non-interactive/print mode (-p)
@@ -58,12 +58,12 @@ Pick the MOST SPECIFIC category that applies:
 
 Boundary rules (use these to resolve ambiguity):
 - Env vars and settings → "config"; terminal display and rendering → "terminal"
-- Keyboard/text input behavior → "input"; slash command system → "slash_commands"
+- Keyboard/text input behavior → "input"; skill/slash command behavior → "skills"
 - Session resume/management → "sessions"; general conversation flow → "sessions"
 - Specific subagent behavior or worktrees → "agents"; general tool behavior → "other"
-- Plugin/skill system features → "plugins"; general features → "other"
 - MCP server/tool management → "mcp"; general tool usage → "other"
 - SDK and -p/print mode → "sdk"; interactive CLI features → use specific category
+- Plugins are composed of skills, agents, hooks, and MCP servers. If a change is about exactly one of those plugin types, use that specific category ("skills", "agents", "hooks", or "mcp"). If a change is about the plugin system in general or about multiple plugin types, use "plugins".
 
 ## Change type guidelines
 

--- a/scripts/enrich.py
+++ b/scripts/enrich.py
@@ -1,6 +1,5 @@
 """Enrich changelog entries with LLM-derived classifications."""
 
-import json
 import os
 from pathlib import Path
 
@@ -19,24 +18,20 @@ CATEGORIES = [
     "mcp", "voice", "auth", "ide", "hooks", "permissions",
     "performance", "agents", "plugins", "config", "api", "sdk", "other",
 ]
-CHANGE_TYPES = ["feature", "bugfix", "improvement", "breaking", "internal"]
+CHANGE_TYPES = ["feature", "bugfix", "improvement", "breaking"]
 COMPLEXITIES = ["minor", "moderate", "major"]
 AUDIENCES = ["interactive_user", "sdk_developer", "admin", "extension_developer"]
 
 BATCH_SIZE = 20
 
 SYSTEM_PROMPT = """\
+<task>
 You classify changelog entries for Claude Code (an AI coding assistant CLI tool).
+For each entry in the input list, determine its category, change type, complexity, and audience.
+Call the classify_entries tool with your classifications.
+</task>
 
-For each entry, output a JSON array of objects with these fields:
-- "index": the entry's position in the input list (0-based)
-- "category": one of %s
-- "change_type": one of %s
-- "complexity": one of %s
-- "audience": one of %s
-
-## Category guidelines
-
+<category-guidelines>
 Pick the MOST SPECIFIC category that applies:
 - "terminal" = terminal rendering, display, cursor, flickering, UI layout, spinner, progress indicators
 - "input" = keyboard handling, text entry, vim mode, readline keybindings, CJK/IME, clipboard/paste
@@ -55,8 +50,9 @@ Pick the MOST SPECIFIC category that applies:
 - "api" = API integration, model providers, Bedrock, Vertex, model selection, rate limits
 - "sdk" = SDK features, SDK messages, SDK configuration, non-interactive/print mode (-p)
 - "other" = doesn't fit any category above
+</category-guidelines>
 
-Boundary rules (use these to resolve ambiguity):
+<boundary-rules>
 - Env vars and settings → "config"; terminal display and rendering → "terminal"
 - Keyboard/text input behavior → "input"; skill/slash command behavior → "skills"
 - Session resume/management → "sessions"; general conversation flow → "sessions"
@@ -64,42 +60,97 @@ Boundary rules (use these to resolve ambiguity):
 - MCP server/tool management → "mcp"; general tool usage → "other"
 - SDK and -p/print mode → "sdk"; interactive CLI features → use specific category
 - Plugins are composed of skills, agents, hooks, and MCP servers. If a change is about exactly one of those plugin types, use that specific category ("skills", "agents", "hooks", or "mcp"). If a change is about the plugin system in general or about multiple plugin types, use "plugins".
+</boundary-rules>
 
-## Change type guidelines
-
+<change-type-guidelines>
 - "feature" = entirely new capability that didn't exist before
 - "improvement" = existing capability made noticeably better (faster, cleaner, more robust, better UX)
 - "bugfix" = something was broken/incorrect and is now fixed (look for "Fixed", "Fix" prefixes)
-- "breaking" = backwards-incompatible change (look for "Breaking" prefix or explicit breaking notes)
-- "internal" = refactoring, test changes, or infra with no user-visible effect
+- "breaking" = backwards-incompatible change (look for "Breaking" prefix, "Deprecated", "Removed", or explicit breaking notes)
+</change-type-guidelines>
 
-## Complexity guidelines
-
+<complexity-guidelines>
 - "minor" = small tweak: single flag, typo fix, one-line behavior change, simple bugfix
 - "moderate" = meaningful change: new command, new integration, workflow change, multi-component fix
 - "major" = large scope: new subsystem, architectural change, major new feature, breaking change
+</complexity-guidelines>
 
-## Audience guidelines
-
+<audience-guidelines>
 Who is the primary target of this change?
 - "interactive_user" = someone using Claude Code interactively in a terminal (most changes)
 - "sdk_developer" = someone building on the SDK, using -p/print mode, or programmatic APIs
 - "admin" = system administrators configuring managed settings, permissions, or deployment
 - "extension_developer" = someone building plugins, hooks, skills, or MCP integrations
+</audience-guidelines>
 
-Return ONLY the JSON array, no other text.""" % (
-    json.dumps(CATEGORIES),
-    json.dumps(CHANGE_TYPES),
-    json.dumps(COMPLEXITIES),
-    json.dumps(AUDIENCES),
-)
+<examples>
+Entry: "Fixed ghost text flickering when typing slash commands mid-input"
+-> category="terminal", change_type="bugfix", complexity="minor", audience="interactive_user"
+Reasoning: Display flickering is terminal rendering; "Fixed" indicates bugfix; single UI glitch is minor.
+
+Entry: "Added support for running skills and slash commands in a forked sub-agent context using `context: fork` in skill frontmatter"
+-> category="skills", change_type="feature", complexity="moderate", audience="extension_developer"
+Reasoning: Skill frontmatter feature; new capability; targets skill authors.
+
+Entry: "Fixed plugin path resolution for file-based marketplace sources"
+-> category="plugins", change_type="bugfix", complexity="minor", audience="extension_developer"
+Reasoning: Plugin marketplace infrastructure, not a specific plugin type; "Fixed" indicates bugfix.
+
+Entry: "Improved memory usage by 3x for large conversations"
+-> category="performance", change_type="improvement", complexity="major", audience="interactive_user"
+Reasoning: Memory optimization; 3x improvement on existing capability; large impact.
+
+Entry: "SDK: Renamed `total_cost` to `total_cost_usd`"
+-> category="sdk", change_type="breaking", complexity="minor", audience="sdk_developer"
+Reasoning: SDK API rename is breaking; small scope but incompatible; targets SDK consumers.
+</examples>"""
+
+CLASSIFY_TOOL = {
+    "name": "classify_entries",
+    "description": "Submit classifications for a batch of changelog entries.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "classifications": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "index": {
+                            "type": "integer",
+                            "description": "The entry's position in the input list (0-based)",
+                        },
+                        "category": {
+                            "type": "string",
+                            "enum": CATEGORIES,
+                        },
+                        "change_type": {
+                            "type": "string",
+                            "enum": CHANGE_TYPES,
+                        },
+                        "complexity": {
+                            "type": "string",
+                            "enum": COMPLEXITIES,
+                        },
+                        "audience": {
+                            "type": "string",
+                            "enum": AUDIENCES,
+                        },
+                    },
+                    "required": ["index", "category", "change_type", "complexity", "audience"],
+                },
+            },
+        },
+        "required": ["classifications"],
+    },
+}
 
 
 DEFAULT_MODEL = "claude-opus-4-6"
 
 FALLBACK_RESULT = {
     "category": "other",
-    "change_type": "internal",
+    "change_type": "improvement",
     "complexity": "minor",
     "audience": "interactive_user",
 }
@@ -113,17 +164,13 @@ def enrich_batch(client: anthropic.Anthropic, entries: list[str], model: str = D
         model=model,
         max_tokens=4096,
         system=SYSTEM_PROMPT,
+        tools=[CLASSIFY_TOOL],
+        tool_choice={"type": "tool", "name": "classify_entries"},
         messages=[{"role": "user", "content": numbered}],
     )
 
-    text = next(b.text for b in response.content if b.type == "text")
-    # Extract JSON from response (handle potential markdown code blocks)
-    text = text.strip()
-    if text.startswith("```"):
-        text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
-
-    results = json.loads(text)
-    return results
+    tool_use = next(b for b in response.content if b.type == "tool_use")
+    return tool_use.input["classifications"]
 
 
 def run_enrichment(model: str, input_path: Path, output_path: Path) -> pd.DataFrame:

--- a/scripts/mapviz.py
+++ b/scripts/mapviz.py
@@ -20,7 +20,7 @@ FILTER_PANEL_HTML = ROOT / "docs" / "filter_panel.html"
 # ── Color palettes (must match dashboard.py) ─────────────────────────────────
 
 CATEGORIES = [
-    "terminal", "input", "slash_commands", "sessions",
+    "terminal", "input", "skills", "sessions",
     "mcp", "voice", "auth", "ide", "hooks", "permissions",
     "performance", "agents", "plugins", "config", "api", "sdk", "other",
 ]
@@ -38,7 +38,6 @@ TYPE_COLORS = {
     "bugfix": "#c4382a",
     "improvement": "#2e6eb8",
     "breaking": "#d4710e",
-    "internal": "#777777",
 }
 
 COMPLEXITY_COLORS = {
@@ -113,7 +112,7 @@ def main():
 
     type_icons = {
         "feature": "✦", "bugfix": "✕", "improvement": "↑",
-        "breaking": "⚠", "internal": "⚙",
+        "breaking": "⚠",
     }
     complexity_dots = {
         "minor": "●○○", "moderate": "●●○", "major": "●●●",


### PR DESCRIPTION
## Summary

- Rename `slash_commands` category to `skills` to reflect the current product direction (slash commands are now part of the skills framework)
- Narrow `plugins` category to plugin infrastructure only; add boundary rule: changes about one plugin type (skills/agents/hooks/mcp) use that specific category, general plugin system uses `plugins`
- Switch from free-form JSON text output to Claude's `tool_use` API for schema-enforced structured output
- Add 5 few-shot examples covering different categories, change types, complexities, and audiences
- Remove unused `internal` change type (only 1 entry out of 1879 ever used it)
- Restructure prompt with XML tags for clearer section delineation
- Update dashboard.py and mapviz.py to match
- Full re-enrichment of all 1879 entries with the new prompt

## Test plan

- [x] Full re-enrichment completed successfully (94 batches, zero errors)
- [x] All downstream pipeline stages (embed, reduce, mapviz, dashboard) run without errors
- [x] Local site verified — categories display correctly, no stale `slash_commands` or `internal` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)